### PR TITLE
set copy to no

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,6 +44,7 @@
     owner: "{{ wildfly_user }}"
     group: "{{ wildfly_user }}"
     creates: "{{ wildfly_prefix }}/{{ wildfly_basename }}"
+    copy: no
 
 - name: create symlink
   file:


### PR DESCRIPTION
In my case, using `ansible 2.0.0.2` the value of copy is yes by default, so Ansible will try to look for `src:` file at `unzip archive` task on the local machine if you do not set `copy: no`